### PR TITLE
Remove ppa:jonathonf

### DIFF
--- a/compose/base/Dockerfile-dev
+++ b/compose/base/Dockerfile-dev
@@ -4,7 +4,6 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:jonathonf/python-3.6
 RUN apt-get update
 
 RUN apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv


### PR DESCRIPTION
Installing Python 3.6 in the Docker base image throws an error at  
`RUN add-apt-repository ppa:jonathonf/python-3.6`  
since this repository has been removed. Fortunately, this Ubuntu version already has Python 3.6 installed so we can safely remove this step from the build file [as can be seen here](https://travis-ci.com/WGierke/concept-to-clinic/builds/141771352).